### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,18 +4,24 @@ on:
   - pull_request
 jobs:
   test:
-    name: Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         node-version:
+          - 20
+          - 18
           - 16
           - 14
           - 12
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
 	],
 	"dependencies": {
 		"bin-version": "^6.0.0",
-		"semver": "^7.3.5",
-		"semver-truncate": "^2.0.0"
+		"semver": "^7.5.3",
+		"semver-truncate": "^3.0.0"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"xo": "^0.39.1"
+		"ava": "^4.3.3",
+		"xo": "^0.45.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ import binaryVersionCheck from './index.js';
 
 test('error when the range does not satisfy the bin version', async t => {
 	await t.throwsAsync(binaryVersionCheck('curl', '1.29.0'), {
-		name: 'InvalidBinaryVersion'
+		name: 'InvalidBinaryVersion',
 	});
 });
 


### PR DESCRIPTION
@sindresorhus I kept the devDependencies as they were, because they drop support for old Node.js.

if it looks good to you, please cut a new version after merging this; it can probably be a minor/patch version since no breaking changes are made AFAICT, but it's your call.